### PR TITLE
add cylinder height and little fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: jeelee <jeelee@student.42seoul.kr>         +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/06/06 19:47:17 by jeelee            #+#    #+#              #
-#    Updated: 2023/06/15 18:17:53 by jeelee           ###   ########.fr        #
+#    Updated: 2023/06/20 17:35:43 by jeelee           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -36,7 +36,7 @@ INC			=	$(SRCDIR)/include
 PARSE		=	parse_file.c valid_file.c parse_gnl.c parse_token.c parse_setting.c light_utils.c parse_number.c parse_utils.c parse_perror.c parse_print.c
 PARSEFIX	=	$(PARSE:%.c=$(PARSEDIR)/%.c)
 
-RAY			=	hit_objects.c create_trgb.c
+RAY			=	hit_objects.c hit_objects2.c create_trgb.c
 RAYFIX		=	$(RAY:%.c=$(RAYDIR)/%.c)
 
 UTILS		=	object_utils.c data_free.c

--- a/src/ray/hit_objects.c
+++ b/src/ray/hit_objects.c
@@ -6,7 +6,7 @@
 /*   By: jeelee <jeelee@student.42seoul.kr>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/14 16:44:45 by jeelee            #+#    #+#             */
-/*   Updated: 2023/06/19 18:54:46 by jeelee           ###   ########.fr       */
+/*   Updated: 2023/06/20 17:32:08 by jeelee           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,36 +57,4 @@ int	hit_plane(t_ray *ray, t_object *obj, double value[])
 	else
 		value[0] = numer / denom;
 	return (1);
-}
-
-int	hit_cylinder(t_ray *ray, t_object *obj, double value[])
-{
-	t_point	o_sub_c;
-	double	a;
-	double	b;
-	double	c;
-
-	o_sub_c = v_sub_vec(ray->origin_point, obj->point);
-	a = v_dot(ray->dir, ray->dir) - pow(v_dot(ray->dir, obj->n_vector), 2);
-	b = 2 * (v_dot(ray->dir, o_sub_c) - \
-		(v_dot(ray->dir, obj->n_vector) * v_dot(o_sub_c, obj->n_vector)));
-	c = v_dot(o_sub_c, o_sub_c) - \
-		pow(v_dot(o_sub_c, obj->n_vector), 2) - pow(obj->diameter / 2, 2);
-	if ((b * b - 4 * a * c) == 0 && fabs(v_dot(ray->dir, obj->n_vector)) == 1)
-	{
-		value[0] = 0;
-		return (1);
-	}
-	return (r_formula(a, b, c, value));
-}
-
-int	hit_con(t_ray *ray, t_object *obj, double value[])
-{
-	int	t;
-
-	t = 0;
-	(void)ray;
-	(void)obj;
-	(void)value;
-	return (t);
 }

--- a/src/ray/hit_objects2.c
+++ b/src/ray/hit_objects2.c
@@ -1,0 +1,74 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   hit_objects2.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: jeelee <jeelee@student.42seoul.kr>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/06/20 17:31:14 by jeelee            #+#    #+#             */
+/*   Updated: 2023/06/20 17:56:53 by jeelee           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../include/minirt.h"
+
+int	cylinder_height(t_ray *ray, t_object *obj, double *value)
+{
+	t_point	p;
+	t_point	p_sub_c;
+	double	p_height;
+
+	p = v_add_vec(ray->origin_point, v_mul_val(ray->dir, *value));
+	p = v_add_vec(ray->origin_point, v_mul_val(ray->dir, *value));
+	p_sub_c = v_sub_vec(p, obj->point);
+	p_height = v_dot(p_sub_c, obj->n_vector);
+	if (0 > p_height || obj->height < p_height)
+	{
+		*value = -1;
+		return (-1);
+	}
+	*value = v_length(p);
+	return (0);
+}
+
+int	cylinder_inf(t_ray *ray, t_object *obj, double *value)
+{
+	t_point	c_sub_p;
+
+	c_sub_p = v_sub_vec(obj->point, ray->origin_point);
+	*value = v_dot(c_sub_p, ray->dir);
+	return (1);
+}
+
+int	hit_cylinder(t_ray *ray, t_object *obj, double value[])
+{
+	t_point	o_sub_c;
+	double	a;
+	double	b;
+	double	c;
+	int		value_num;
+
+	o_sub_c = v_sub_vec(ray->origin_point, obj->point);
+	a = v_dot(ray->dir, ray->dir) - pow(v_dot(ray->dir, obj->n_vector), 2);
+	b = 2 * (v_dot(ray->dir, o_sub_c) - \
+		(v_dot(ray->dir, obj->n_vector) * v_dot(o_sub_c, obj->n_vector)));
+	c = v_dot(o_sub_c, o_sub_c) - \
+		pow(v_dot(o_sub_c, obj->n_vector), 2) - pow(obj->diameter / 2, 2);
+	if ((b * b - 4 * a * c) == 0 && fabs(v_dot(ray->dir, obj->n_vector)) == 1)
+		return (cylinder_inf(ray, obj, &value[0]));
+	value_num = r_formula(a, b, c, value);
+	value_num += cylinder_height(ray, obj, &value[0]) + \
+		cylinder_height(ray, obj, &value[1]);
+	return (value_num);
+}
+
+int	hit_con(t_ray *ray, t_object *obj, double value[])
+{
+	int	t;
+
+	t = 0;
+	(void)ray;
+	(void)obj;
+	(void)value;
+	return (t);
+}


### PR DESCRIPTION
## hit_cylinder 수정
- [x] t값을 맞게 수정하였습니다.
  - t값이 과정을 풀어보다가 알게 되었는데 거리 값이긴 하나 제 식에서는 `O + tv`(`ray->origin_point + (t * ray->dir)`)에서 구한 t이기 때문입니다.
  - 이를 이용해 교점인 P를 구한 후 카메라 원점부터의 거리를 t로 두었습니다.
- [x] cylinder_height 추가
  - 기존의 식은 height값을 적용시킨 것이 아니라 무한대로 뻗어나가는 원통형의 교점을 구한겁니다.
  - 교점 P를 구한 후, cylinder의 원점에서부터의 교점 P의 벡터에서 법선벡터의 내적이 높이를 넘으면 높이 위의 점이기 때문에 `해가 없다`로 판단하였습니다.