### PR TITLE
combine only_*, hit_obj & remove t_rec of hit_obj

### DIFF
--- a/src/include/ray.h
+++ b/src/include/ray.h
@@ -6,10 +6,9 @@
 /*   By: jeelee <jeelee@student.42seoul.kr>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/14 17:37:53 by jeelee            #+#    #+#             */
-/*   Updated: 2023/07/08 18:51:25 by jeelee           ###   ########.fr       */
+/*   Updated: 2023/07/09 18:30:59 by jeelee           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
-
 
 #ifndef RAY_H
 # define RAY_H
@@ -26,20 +25,18 @@ uint32_t	specular(t_light *light, t_rec *rec, t_ray *ray);
 
 double		max(double a, double b);
 
-double		hit_objs(t_ray *ray, t_object *obj, t_rec *rec);
+double		hit_objs(t_ray *ray, t_object *obj);
 
 int			r_formula(double a, double b, double c, double value[]);
-int			is_front(t_camera *cam, t_object *obj, double t);
 
 int			hit_sphere(t_ray *ray, t_object *obj, double value[]);
 int			hit_plane(t_ray *ray, t_object *obj, double value[]);
 int			hit_cylinder(t_ray *ray, t_object *obj, double value[]);
 int			hit_cone(t_ray *ray, t_object *obj, double value[]);
-int			hit_circle(t_ray *ray, t_object *obj, double value[], t_rec *rec);
-int			only_hit_circle(t_ray *ray, t_object *obj, double value[]);
+int			hit_circle(t_ray *ray, t_object *obj);
 
-t_rec		get_intersection(t_ray *ray, t_object *obj);// ray와 obj의 교점을 가지고 온다.
-t_rec		find_closestobj(t_ray *ray, t_object **objs);// 교점 중 가장 가까운 오브젝트
+t_rec		get_intersection(t_ray *ray, t_object *obj);
+t_rec		find_closestobj(t_ray *ray, t_object **objs);
 
 int			is_shadow(t_object **objs, t_light *light, t_point frag_point);
 

--- a/src/ray/hit_circle.c
+++ b/src/ray/hit_circle.c
@@ -6,7 +6,7 @@
 /*   By: jeelee <jeelee@student.42seoul.kr>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/28 14:58:16 by jeelee            #+#    #+#             */
-/*   Updated: 2023/07/07 21:01:58 by jeelee           ###   ########.fr       */
+/*   Updated: 2023/07/09 18:18:21 by jeelee           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,51 +28,7 @@ static int	_hit_circle(t_point h, t_ray *ray, t_object *obj)
 	return (t);
 }
 
-static int	parse_value(double c_value, double value[], t_rec *rec)
-{
-	if (c_value < 0)
-		return (0);
-	else
-	{
-		if (value[0] < 0)
-		{
-			rec->hit_shape = circle;
-			return (1);
-		}
-		else if (value[1] < 0)
-			value[0] = c_value;
-		else
-		{
-			value[0] = c_value;
-			value[1] = -1;
-			return (-1);
-		}
-		rec->hit_shape = circle;
-	}
-	return (0);
-}
-
-static int	only_parse_value(double c_value, double value[])
-{
-	if (c_value < 0)
-		return (0);
-	else
-	{
-		if (value[0] < 0)
-			return (1);
-		else if (value[1] < 0)
-			value[0] = c_value;
-		else
-		{
-			value[0] = c_value;
-			value[1] = -1;
-			return (-1);
-		}
-	}
-	return (0);
-}
-
-int	hit_circle(t_ray *ray, t_object *obj, double value[], t_rec *rec)
+int	hit_circle(t_ray *ray, t_object *obj)
 {
 	double	b_value;
 	double	t_value;
@@ -86,28 +42,10 @@ int	hit_circle(t_ray *ray, t_object *obj, double value[], t_rec *rec)
 	{
 		h = v_add_vec(obj->point, v_mul_val(obj->n_vector, -(obj->height / 2)));
 		t_value = _hit_circle(h, ray, obj);
-		if (t_value != -1 && t_value < b_value)
+		if (t_value >= 0 && t_value < b_value)
 			b_value = t_value;
 	}
-	return (parse_value(b_value, value, rec));
-}
-
-int	only_hit_circle(t_ray *ray, t_object *obj, double value[])
-{
-	double	b_value;
-	double	t_value;
-	t_point	h;
-
-	if (v_dot(ray->dir, obj->n_vector) == 0)
-		return (0);
-	h = v_add_vec(obj->point, v_mul_val(obj->n_vector, obj->height / 2));
-	b_value = _hit_circle(h, ray, obj);
-	if (obj->shape == cylinder)
-	{
-		h = v_add_vec(obj->point, v_mul_val(obj->n_vector, -(obj->height / 2)));
-		t_value = _hit_circle(h, ray, obj);
-		if (t_value != -1 && t_value < b_value)
-			b_value = t_value;
-	}
-	return (only_parse_value(b_value, value));
+	if (b_value < 0)
+		return (-1);
+	return (b_value);
 }

--- a/src/ray/hit_objects.c
+++ b/src/ray/hit_objects.c
@@ -3,16 +3,16 @@
 /*                                                        :::      ::::::::   */
 /*   hit_objects.c                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jhwang2 <jhwang2@student.42.fr>            +#+  +:+       +#+        */
+/*   By: jeelee <jeelee@student.42seoul.kr>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/14 16:44:45 by jeelee            #+#    #+#             */
-/*   Updated: 2023/07/06 18:11:57 by jhwang2          ###   ########.fr       */
+/*   Updated: 2023/07/09 18:29:54 by jeelee           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../include/minirt.h"
 
-double	hit_objs(t_ray *ray, t_object *obj, t_rec *rec)
+double	hit_objs(t_ray *ray, t_object *obj)
 {
 	int		value_num;
 	double	value[2];
@@ -25,11 +25,9 @@ double	hit_objs(t_ray *ray, t_object *obj, t_rec *rec)
 	else if (obj->shape == plane)
 		value_num = hit_plane(ray, obj, value);
 	else if (obj->shape == cylinder)
-		value_num = hit_cylinder(ray, obj, value) + \
-			hit_circle(ray, obj, value, rec);
+		value_num = hit_cylinder(ray, obj, value);
 	else if (obj->shape == cone)
-		value_num = hit_cone(ray, obj, value) + \
-			hit_circle(ray, obj, value, rec);
+		value_num = hit_cone(ray, obj, value);
 	if (value[0] < 0)
 	{
 		if (value_num == 2 && value[1] >= 0)
@@ -37,18 +35,6 @@ double	hit_objs(t_ray *ray, t_object *obj, t_rec *rec)
 		return (-1);
 	}
 	return (value[0]);
-}
-
-int	is_front(t_camera *cam, t_object *obj, double t)
-{
-	t_point	hit_point;
-	t_point	obj_nv;
-
-	hit_point = v_add_vec (cam->ray.origin_point, v_mul_val (cam->ray.dir, t));
-	obj_nv = v_unit(v_sub_vec (hit_point, obj->point));
-	if (v_dot (cam->ray.dir, obj_nv) < 0)
-		return (1);
-	return (0);
 }
 
 int	r_formula(double a, double b, double c, double value[])

--- a/src/ray/ray_utils.c
+++ b/src/ray/ray_utils.c
@@ -6,7 +6,7 @@
 /*   By: jeelee <jeelee@student.42seoul.kr>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/05 15:46:49 by jeelee            #+#    #+#             */
-/*   Updated: 2023/07/08 19:42:36 by jeelee           ###   ########.fr       */
+/*   Updated: 2023/07/09 18:10:17 by jeelee           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,11 +64,22 @@ static t_point	get_n_vector(t_ray *ray, t_point p, \
 t_rec	get_intersection(t_ray *ray, t_object *obj)
 {
 	t_rec	rec;
+	double	circle_dist;
 
+	circle_dist = -1;
 	ft_memset(&rec, 0, sizeof(t_rec));
 	rec.hit_obj = obj;
 	rec.hit_shape = obj->shape;
-	rec.t = hit_objs(ray, obj, &rec);
+	rec.t = hit_objs(ray, obj);
+	if (obj->shape == cylinder || obj->shape == cone)
+	{
+		circle_dist = hit_circle(ray, obj);
+		if (0 <= circle_dist && circle_dist < rec.t)
+		{
+			rec.t = circle_dist;
+			rec.hit_shape = circle;
+		}
+	}
 	rec.frag_point = v_add_vec(ray->origin_point, v_mul_val(ray->dir, rec.t));
 	rec.n_vector = get_n_vector(ray, rec.frag_point, rec.hit_shape, obj);
 	return (rec);

--- a/src/ray/shadow.c
+++ b/src/ray/shadow.c
@@ -6,37 +6,25 @@
 /*   By: jeelee <jeelee@student.42seoul.kr>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/04 15:19:17 by jhwang2           #+#    #+#             */
-/*   Updated: 2023/07/07 21:37:56 by jeelee           ###   ########.fr       */
+/*   Updated: 2023/07/09 18:16:45 by jeelee           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../include/minirt.h"
 
-static double	only_hit_objs(t_ray *ray, t_object *obj)
+static double	check_block(t_ray *ray, t_object *obj)
 {
-	int		value_num;
-	double	value[2];
+	double	t;
+	double	circle_dist;
 
-	value_num = 0;
-	value[0] = -1;
-	value[1] = -1;
-	if (obj->shape == sphere)
-		value_num = hit_sphere(ray, obj, value);
-	else if (obj->shape == plane)
-		value_num = hit_plane(ray, obj, value);
-	else if (obj->shape == cylinder)
-		value_num = hit_cylinder(ray, obj, value) + \
-			only_hit_circle(ray, obj, value);
-	else if (obj->shape == cone)
-		value_num = hit_cone(ray, obj, value) + \
-			only_hit_circle(ray, obj, value);
-	if (value[0] < 0)
+	t = hit_objs(ray, obj);
+	if (obj->shape == cylinder || obj->shape == cone)
 	{
-		if (value_num == 2 && value[1] >= 0)
-			return (value[1]);
-		return (-1);
+		circle_dist = hit_circle(ray, obj);
+		if (0 <= circle_dist && circle_dist < t)
+			return (circle_dist);
 	}
-	return (value[0]);
+	return (t);
 }
 
 int	is_shadow(t_object **objs, t_light *light, t_point frag_point)
@@ -54,7 +42,7 @@ int	is_shadow(t_object **objs, t_light *light, t_point frag_point)
 	i = -1;
 	while (objs[++i])
 	{
-		t = only_hit_objs(&ray, objs[i]);
+		t = check_block(&ray, objs[i]);
 		if (0.00001 < t && t <= max)
 			return (1);
 	}


### PR DESCRIPTION
## 기존 hit_obj 함수를 수정했습니다.
- [x] 기존의 hit_obj() 함수 파라미터 중에 t_rec을 받아서 썼었는데 hit_circle을 밖으로 빼서 단순화시켰습니다.
  - 그래서 이제 `hit_obj()`는 `cylinder`, `cone`의 뚜껑의 hit_point까지 찾아주지는 않습니다.
  - 이 과정으로 shadow에서 `only_hit_obj()`대신 `hit_obj()`를 사용합니다. ( `only_*()`을 다 지웠습니다. )
  - `hit_circle()`은 `hit_obj()`를 진행한 다음에 hit_obj가 `cylinder`, `cone`이라면 실행시킵니다.
    + 단순히 `t`값만 구한 후, `rec->t`의 값과 비교해 더 작은 값을 집어넣습니다.